### PR TITLE
Intruduced basic CMake configuration

### DIFF
--- a/BoostDetailConfig.cmake
+++ b/BoostDetailConfig.cmake
@@ -1,0 +1,12 @@
+# Copyright 2018 Thomas Jandecka
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+include(CMakeFindDependencyMacro)
+find_dependency(BoostCore 1.66)
+find_dependency(BoostConfig 1.66)
+find_dependency(BoostAssert 1.66)
+find_dependency(BoostStaticAssert 1.66)
+find_dependency(BoostTypeTraits 1.66)
+find_dependency(BoostUtility 1.66)
+include("${CMAKE_CURRENT_LIST_DIR}/BoostDetailTargets.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,58 @@
+# Copyright 2018 Thomas Jandecka
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+
+project(BoostDetail VERSION 1.66 LANGUAGES CXX)
+
+add_library(detail INTERFACE)
+
+target_include_directories(detail INTERFACE 
+    $<BUILD_INTERFACE:${BoostDetail_BINARY_DIR}/include>
+    $<BUILD_INTERFACE:${BoostDetail_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    )
+
+find_package(BoostCore 1.66 REQUIRED)
+find_package(BoostConfig 1.66 REQUIRED)
+find_package(BoostAssert 1.66 REQUIRED)
+find_package(BoostStaticAssert 1.66 REQUIRED)
+find_package(BoostTypeTraits 1.66 REQUIRED)
+find_package(BoostUtility 1.66 REQUIRED)
+
+target_link_libraries(detail
+    INTERFACE
+        Boost::core
+        Boost::config
+        Boost::assert
+        Boost::static_assert
+        Boost::type_traits
+        Boost::utility
+    )
+
+install(EXPORT detail-targets
+    FILE BoostDetailTargets.cmake
+    NAMESPACE Boost::
+    DESTINATION lib/cmake/boost
+    )
+
+install(TARGETS detail EXPORT detail-targets
+    INCLUDES DESTINATION include
+    )
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("BoostDetailConfigVersion.cmake"
+    VERSION ${BoostDetail_VERSION}
+    COMPATIBILITY SameMajorVersion
+    )
+install(
+    FILES
+        "BoostDetailConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/BoostDetailConfigVersion.cmake"
+    DESTINATION
+        lib/cmake/boost
+    )
+install(DIRECTORY include/ DESTINATION include)
+
+add_library(Boost::detail ALIAS detail)


### PR DESCRIPTION
Expresses Boost::detail as an `INTERFACE` library in CMake.
- use via `add_subdirectory` 
- use via `find_package(BoostDetail 1.66)` if previously installed. This is achieved via the following install:
```
$INSTALL_PREFIX
├── include
│   └── boost
│       ├── blank_fwd.hpp
│       ├── blank.hpp
│       ├── cstdlib.hpp
│       └── detail
│           ├── allocator_utilities.hpp
│           ├── binary_search.hpp
│           ├── bitmask.hpp
│           ├── catch_exceptions.hpp
│           ├── container_fwd.hpp
│           ├── fenv.hpp
│           ├── has_default_constructor.hpp
│           ├── identifier.hpp
│           ├── indirect_traits.hpp
│           ├── is_incrementable.hpp
│           ├── is_sorted.hpp
│           ├── is_xxx.hpp
│           ├── lightweight_main.hpp
│           ├── lightweight_test_report.hpp
│           ├── named_template_params.hpp
│           ├── numeric_traits.hpp
│           ├── reference_content.hpp
│           ├── select_type.hpp
│           ├── templated_streams.hpp
│           ├── utf8_codecvt_facet.hpp
│           └── utf8_codecvt_facet.ipp
└── lib
    └── cmake
        └── boost
            ├── BoostDetailConfig.cmake
            ├── BoostDetailConfigVersion.cmake
            └── BoostDetailTargets.cmake

6 directories, 27 files
```
- tests are __not__ included in the build